### PR TITLE
feat: load template files directly from the binary

### DIFF
--- a/cmd/diffty/main.go
+++ b/cmd/diffty/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"path/filepath"
 
 	"github.com/darccio/diffty/internal/server"
 	"github.com/darccio/diffty/internal/storage"
@@ -23,8 +22,7 @@ func main() {
 	}
 
 	// Setup server and routes
-	templateDir := filepath.Join("internal", "server", "templates")
-	srv, err := server.New(store, templateDir)
+	srv, err := server.New(store)
 	if err != nil {
 		log.Fatalf("Failed to initialize server: %v", err)
 	}


### PR DESCRIPTION
Hello @darccio, thanks for this nice tool!
Currently you must run the binary from its directory in order to load the template files.
With this PR you can now run it from anywhere by loading the files directly from the binary itself.
I hope this will be of you interest :)
Otherwise, feel free to close the PR.
Regards,
Alessio